### PR TITLE
Fixes bug where custom prepatch string could not be applied

### DIFF
--- a/bin/releasy.js
+++ b/bin/releasy.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var program = require('commander'),
   Releasy = require('../lib/releasy'),
+  camelCase = require('camelcase'),
   pkg = require('../package.json'),
   steps = require('../lib/steps');
 
@@ -12,7 +13,7 @@ if (['major', 'minor', 'patch', 'promote', 'prerelease', 'pre'].indexOf(argument
   type = arguments[2];
   if (type === 'pre') type = 'prerelease';
   console.log("Release:", type);
-  
+
   arguments = arguments.slice(0, 2).concat(arguments.slice(3));
 }
 
@@ -47,8 +48,10 @@ var defaults = {
   'quiet': false
 };
 
-for (var key in defaults)
-  program[key] = program[key] || optionsFile[key] || defaults[key];
+for (var key in defaults) {
+  var ccKey = camelCase(key)
+  program[ccKey] = program[ccKey] || optionsFile[key] || defaults[key];
+}
 
 program.type = type;
 program.cli = true;

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -9,7 +9,7 @@ module.exports = function(opts) {
 
   var versionProvider = this.steps.pickVersionProvider(opts.filename);
 
-  var config = this.steps.setup(versionProvider, opts.type, opts.stable ? 'stable' : opts['tag-name']);
+  var config = this.steps.setup(versionProvider, opts.type, opts.stable ? 'stable' : opts['tagName']);
   if (!opts.quiet) {
     console.log("Old version: " + config.oldVersion.bold);
     console.log("New version: " + config.newVersion.bold.yellow);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/vtex/releasy",
   "dependencies": {
+    "camelcase": "^4.0.0",
     "commander": "~2.9.0",
     "js-yaml": "^3.6.1",
     "prompt": "~0.3.0",


### PR DESCRIPTION
Fixes a bug where the tag name (pre-patch string) could not be customized, neither by command line nor config file 

The fix is based on standardizing the program keys using camel-case
Based on [commander documentation](https://www.npmjs.com/package/commander): "Multi-word options such as "--template-engine" are camel-cased, becoming program.templateEngine"

Testing with command-line argument:
```shell
$ ./bin/releasy.js -t hml
Old version: 1.7.1
New version: 1.7.2-hml
```

Testing with config file:
```yml
# _releasy.yml
tag-name: hml
```
```
$ ./bin/releasy.js
Old version: 1.7.1
New version: 1.7.2-hml
```