### PR TITLE
Update CHANGELOG.md when exists and post a Release Notes on github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop or mobile):
+* Link to your project:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+#### What is the purpose of this pull request?
+<!--- Describe your changes in detail. -->
+
+#### What problem is this solving?
+<!--- What is the motivation and context for this change? -->
+
+#### How should this be manually tested?
+
+#### Screenshots or example usage
+
+#### Types of changes
+- [ ] Bug fix (a non-breaking change which fixes an issue)
+- [ ] New feature (a non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Requires change to documentation, which has been updated accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.8.0] - 2018-5-30
+### Added
+- Update CHANGELOG.md when exists and post a Release Notes in github repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.8.0] - 2018-5-30
 ### Added
 - Update CHANGELOG.md when exists and post a Release Notes in github repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.0] - 2018-6-1
+
 ### Added
 - Update CHANGELOG.md when exists and post a Release Notes in github repository

--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ If the specified file has a `.json` extension, it will be treated as Node's `pac
 If the specified file has a `.cs` extension, it will be treated as an `AssemblyInfo.cs` file. As such, the version will be read from and written to assembly version attributes, which are: [`AssemblyVersion`](http://msdn.microsoft.com/en-us/library/system.reflection.assemblyversionattribute(v=vs.110).aspx), [`AssemblyFileVersion`](http://msdn.microsoft.com/en-us/library/system.reflection.assemblyfileversionattribute(v=vs.110).aspx) and [`AssemblyInformationalVersion`](http://msdn.microsoft.com/en-us/library/system.reflection.assemblyinformationalversionattribute(v=vs.110).aspx).
 
 In order to conform to the .NET Framework's specification, only the `AssemblyInformationalVersion` attribute will retain any prerelease version information, while the other two will be stripped of it, keeping only the version numbers.
+
+## Settings
+
+A [GitHub Personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) will be needed to create the release on GitHub. Whe you created, add this token to an environment variable named `GITHUB_API_TOKEN` in your `~/.bash_profile`.

--- a/bin/releasy.js
+++ b/bin/releasy.js
@@ -48,8 +48,8 @@ var defaults = {
   'quiet': false
 };
 
-for (var key in defaults) {
-  var ccKey = camelCase(key)
+for (let key in defaults) {
+  let ccKey = camelCase(key)
   program[ccKey] = program[ccKey] || optionsFile[key] || defaults[key];
 }
 

--- a/bin/releasy.js
+++ b/bin/releasy.js
@@ -58,7 +58,7 @@ program.cli = true;
 
 try {
   return new Releasy(program);
-} catch(error) {
+} catch (error) {
   console.error(error.message.red);
   exit(1);
 }

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -1,7 +1,7 @@
 require('shelljs/global');
 var path = require('path');
 
-module.exports = (function(){
+module.exports = (function () {
   var folder = path.dirname(module.filename) + '/providers';
   var files = ls(folder);
   var modules = [];

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -1,13 +1,12 @@
 require('shelljs/global');
 var path = require('path');
 
-module.exports = (function () {
-  var folder = path.dirname(module.filename) + '/providers';
-  var files = ls(folder);
-  var modules = [];
-  files.forEach(function (file) {
+module.exports = (() => {
+  let folder = path.dirname(module.filename) + '/providers';
+  let files = ls(folder);
+  let modules = [];
+  files.forEach(file => {
     modules.push(require('./providers/' + file));
   })
-
   return modules;
 })();

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -30,7 +30,7 @@ module.exports = function (opts) {
   config.changelogPath = 'CHANGELOG.md';
   config.githubAuth = getGithubToken();
   config.changelogVersion = `\n\n## [${config.newVersion}] - ${year}-${month}-${day}`;
-  config.githubUrl = `https://api.github.com/repos/${getGithubRepo()}/releases`;
+  config.githubInfo = getGithubRepo();
   config.release = {
     name: config.tagName,
     tag_name: config.tagName,
@@ -47,9 +47,8 @@ module.exports = function (opts) {
     if (!process.env.GITHUB_API_TOKEN) {
       console.log('You must to set GITHUB_API_TOKEN env if you want post the Release Notes of your project.\
     \nSee our settings section on Readme to do it.'.yellow.bold)
-    } else return `"Authorization token ${process.env.GITHUB_API_TOKEN}"`;
+    } else return process.env.GITHUB_API_TOKEN
   }
-
   /**
    * Get information in CHANGELOG.md about
    * new version that will be released.
@@ -81,12 +80,12 @@ module.exports = function (opts) {
     gitUrlCommand = 'git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3'
     const url = execSync(gitUrlCommand).toString().trim();
     if (url.includes('git@git')) {
-      const [repo] = url.split(":").slice(1)
+      [aux] = url.split(":").slice(1)
+      const repo = aux.split("/")
       return repo
     }
-    const [org] = url.split("/").slice(3)
-    const [repo] = url.replace(".git", "").split("/").slice(4)
-    return `${org}/${repo}`
+    const repo = url.replace(".git", "").split("/").slice(3)
+    return repo
   }
 
   // No prompt necessary, release and finish.

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -44,7 +44,7 @@ module.exports = function (opts) {
      * @return Github Authorization
     */
   function getGithubToken() {
-    if (!process.env.GITHUB_API_TOKEN) {
+    if (process.env.GITHUB_API_TOKEN) {
       return process.env.GITHUB_API_TOKEN
     }
     if (!config.quiet) console.log('You must set GITHUB_API_TOKEN env if you want to post the Release Notes of your project.\

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -1,7 +1,9 @@
-var steps = require('./steps'),
-  prompt = require('prompt');
+var steps = require('./steps')
+var prompt = require('prompt')
+var execSync = require('child_process').execSync
+var fs = require('fs')
 
-module.exports = function(opts) {
+module.exports = function (opts) {
   // Expose this to unit testing
   _this = this;
   this.steps = opts.steps || steps;
@@ -15,6 +17,7 @@ module.exports = function(opts) {
     console.log("New version: " + config.newVersion.bold.yellow);
   }
 
+  const [month, day, year] = new Date().toLocaleDateString('en-US').split('/');
   // Pachamama v2 requires that version tags start with a 'v' character.
   config.tagName = 'v' + config.newVersion;
   config.commitMessage = 'Release ' + config.tagName;
@@ -23,6 +26,68 @@ module.exports = function(opts) {
   config.npmFolder = opts.npmFolder;
   config.dryRun = opts.dryRun;
   config.quiet = opts.quiet;
+  config.unreleased = '## [Unreleased]'
+  config.changelogPath = 'CHANGELOG.md';
+  config.githubAuth = getGithubToken();
+  config.changelogVersion = `\n\n## [${config.newVersion}] - ${year}-${month}-${day}`;
+  config.githubUrl = `https://api.github.com/repos/${getGithubRepo()}/releases`;
+  config.release = {
+    name: config.tagName,
+    tag_name: config.tagName,
+    body: getReleaseNotes() || " ",
+    draft: false,
+    prerelease: false,
+  }
+
+  /**
+     * Get and format GITHUB_API_TOKEN.
+     * @return Github Authorization
+    */
+  function getGithubToken() {
+    if (!process.env.GITHUB_API_TOKEN) {
+      console.log('You must to set GITHUB_API_TOKEN env if you want post the Release Notes of your project.\
+    \nSee our settings section on Readme to do it.'.yellow.bold)
+    } else return `"Authorization token ${process.env.GITHUB_API_TOKEN}"`;
+  }
+
+  /**
+   * Get information in CHANGELOG.md about
+   * new version that will be released.
+   * @return release notes between versions
+  */
+  function getReleaseNotes() {
+    if (!fs.existsSync(config.changelogPath)) {
+      console.log("Create a CHANGELOG.md if you want a Release Notes in your Github Project".red.bold)
+      return
+    }
+    const data = fs.readFileSync(config.changelogPath, err => {
+      if (err) throw `Error reading file: ${err}`;
+    }).toString()
+    if (data.indexOf(config.unreleased) < 0) {
+      console.log("I can't post your Release Notes. :( \
+        \nMake your CHANGELOG great again and follow the CHANGELOG format http://keepachangelog.com/en/1.0.0/".yellow.bold)
+      return
+    }
+    const unreleased = data.indexOf(config.unreleased) + config.unreleased.length;
+    const oldVersion = data.indexOf(config.oldVersion) - 4;
+    return data.substring(unreleased, oldVersion)
+  }
+
+  /**
+   * Get information about org and repo name
+   * @return git organization and repo names
+  */
+  function getGithubRepo() {
+    gitUrlCommand = 'git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3'
+    const url = execSync(gitUrlCommand).toString().trim();
+    if (url.includes('git@git')) {
+      const [repo] = url.split(":").slice(1)
+      return repo
+    }
+    const [org] = url.split("/").slice(3)
+    const [repo] = url.replace(".git", "").split("/").slice(4)
+    return `${org}/${repo}`
+  }
 
   // No prompt necessary, release and finish.
   if (!opts.cli || opts.silent) {

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -45,10 +45,12 @@ module.exports = function (opts) {
     */
   function getGithubToken() {
     if (!process.env.GITHUB_API_TOKEN) {
-      console.log('You must to set GITHUB_API_TOKEN env if you want post the Release Notes of your project.\
-    \nSee our settings section on Readme to do it.'.yellow.bold)
-    } else return process.env.GITHUB_API_TOKEN
+      return process.env.GITHUB_API_TOKEN
+    }
+    if (!config.quiet) console.log('You must set GITHUB_API_TOKEN env if you want to post the Release Notes of your project.\
+    \nCheck the settings section in README for details on how to do it.'.yellow.bold)
   }
+
   /**
    * Get information in CHANGELOG.md about
    * new version that will be released.
@@ -56,20 +58,22 @@ module.exports = function (opts) {
   */
   function getReleaseNotes() {
     if (!fs.existsSync(config.changelogPath)) {
-      console.log("Create a CHANGELOG.md if you want a Release Notes in your Github Project".red.bold)
+      if (!config.quiet) console.log("Create a CHANGELOG.md if you want a Release Notes in your Github Project".red.bold)
       return
     }
     const data = fs.readFileSync(config.changelogPath, err => {
       if (err) throw `Error reading file: ${err}`;
     }).toString()
     if (data.indexOf(config.unreleased) < 0) {
-      console.log("I can't post your Release Notes. :( \
+      if (!config.quiet) console.log("I can't post your Release Notes. :(\
         \nMake your CHANGELOG great again and follow the CHANGELOG format http://keepachangelog.com/en/1.0.0/".yellow.bold)
       return
     }
     const unreleased = data.indexOf(config.unreleased) + config.unreleased.length;
     const oldVersion = data.indexOf(config.oldVersion) - 4;
-    return data.substring(unreleased, oldVersion)
+    return oldVersion < 0 ?
+      data.substring(unreleased) :
+      data.substring(unreleased, oldVersion)
   }
 
   /**
@@ -102,14 +106,14 @@ module.exports = function (opts) {
     description: 'Are you sure?'.green,
     default: 'yes',
     required: true,
-    before: function (value) {
+    before: value => {
       return value === 'yes' || value === 'y';
     }
   };
 
-  prompt.get(property, function (err, result) {
+  prompt.get(property, (err, result) => {
     if (err || !result.confirm) {
-      return console.log("Cancelled by user");
+      return console.log("\nCancelled by user");
     }
     _this.steps.release(config, opts);
   });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -10,8 +10,8 @@ var yaml = require('js-yaml');
 var providers = require('./providers.js');
 
 var steps = {
-    getOptionsFile: function() {
-        var possibleFiles = [ '_releasy.yaml', '_releasy.yml', '_releasy.json'];
+    getOptionsFile: function () {
+        var possibleFiles = ['_releasy.yaml', '_releasy.yml', '_releasy.json'];
         for (var i = 0; i < possibleFiles.length; i++) {
             var name = possibleFiles[i];
             if (test('-e', name))
@@ -19,9 +19,7 @@ var steps = {
         }
         return {};
     },
-    pickVersionProvider: function(fileName, overrideProviders) {
-
-
+    pickVersionProvider: function (fileName, overrideProviders) {
         var currentProviders = overrideProviders || providers;
         for (var i in currentProviders) {
             var provider = currentProviders[i];
@@ -32,7 +30,7 @@ var steps = {
 
         throw new Error(util.format("Unable to find a provider that supports '%s' as a version file", fileName));
     },
-    setup: function(versionProvider, type, prerelease) {
+    setup: function (versionProvider, type, prerelease) {
         var version = versionProvider.readVersion();
         // Support for "promote" predicate, which bumps prerelease to stable, without changing version number.
         if (type === 'promote') {
@@ -48,10 +46,10 @@ var steps = {
         // For other types, simply increment
         else {
             var incrementType = type === 'prerelease'
-              || prerelease === 'stable'
-              || version.prerelease.length === 0
+                || prerelease === 'stable'
+                || version.prerelease.length === 0
                 ? type || 'patch'
-                : ('pre'+type) || 'prepatch'
+                : ('pre' + type) || 'prepatch'
             version = version.inc(incrementType);
         }
         if (prerelease && prerelease !== 'stable' && type != 'prerelease') {
@@ -63,7 +61,7 @@ var steps = {
             oldVersion: versionProvider.readVersion().format()
         };
     },
-    scripts: function(msg, config, key) {
+    scripts: function (msg, config, key) {
         var pkg = /package\.json$/.test(config.versionProvider.filePath);
         var manifest = /manifest\.json$/.test(config.versionProvider.filePath);
 
@@ -71,26 +69,26 @@ var steps = {
         try {
             var cmd = config.versionProvider.getScript(key);
         }
-        catch(err) {
+        catch (err) {
             return Q();
         }
         return cmd ?
             steps.spawn(cmd, msg, config.dryRun, config.quiet)
             : Q();
     },
-    preReleasy: function(config) {
+    preReleasy: function (config) {
         var msg = 'Pre releasy';
         return steps.status(config)
-            .then(function(stdout) {
+            .then(function (stdout) {
                 if (!config.dryRun && stdout[0].indexOf('nothing to commit') === -1) {
                     throw '\nPlease commit your changes before proceeding.';
                 } else {
                     return Q();
                 }
             })
-            .then(function() { return steps.scripts(msg, config, 'prereleasy'); })
-            .then(function() { return steps.status(config); })
-            .then(function(stdout) {
+            .then(function () { return steps.scripts(msg, config, 'prereleasy'); })
+            .then(function () { return steps.status(config); })
+            .then(function (stdout) {
                 if (stdout[0].indexOf('nothing to commit') > -1) return Q();
                 var cmd = config.versionProvider.getScript('prereleasy');
                 var preCfg = {
@@ -104,17 +102,17 @@ var steps = {
                 return steps.commit(preCfg);
             });
     },
-    run: function(cmd, successMessage, dryRun, quiet){
+    run: function (cmd, successMessage, dryRun, quiet) {
         var promise = dryRun ? Q() : Q.nfcall(exec, cmd);
-        if (successMessage) promise.then(function(stdout) {
+        if (successMessage) promise.then(function (stdout) {
             if (!quiet) console.log(successMessage + " > ".blue + cmd.blue);
             return stdout;
         });
         return promise;
     },
-    spawn: function(cmd, successMessage, dryRun, quiet) {
+    spawn: function (cmd, successMessage, dryRun, quiet) {
         var deferred = Q.defer();
-        deferred.promise.then(function() {
+        deferred.promise.then(function () {
             if (!quiet) console.log(successMessage + " > ".blue + cmd.blue);
         });
         if (dryRun) {
@@ -138,50 +136,75 @@ var steps = {
             var command = args.shift();
         }
         var childProcess = spawn(command, args, { env: childEnv, stdio: childIO, windowsVerbatimArguments: argsW32 });
-        childProcess.on('close', function(code) {
+        childProcess.on('close', function (code) {
             if (code === 0) deferred.resolve();
             else deferred.reject('\nCommand exited with error code: ' + code);
         });
         return deferred.promise;
     },
-    status: function(config) {
-        return steps.run('git status', '', false, config.quiet).then(function(stdout) {
+    status: function (config) {
+        return steps.run('git status', '', false, config.quiet).then(function (stdout) {
             return stdout;
         });
     },
     bump: function (config) {
+        // Update version on CHANGELOG.md 
+        if (fs.existsSync(config.changelogPath)) {
+            const data = fs.readFileSync(config.changelogPath, err => {
+                if (err) throw `Error reading file: ${err}`;
+            }).toString()
+            if (data.indexOf(config.unreleased) < 0) {
+                console.log("I can't update your CHANGELOG. :( \
+                  \nMake your CHANGELOG great again and follow the CHANGELOG format http://keepachangelog.com/en/1.0.0/".red.bold)
+            } else {
+                const position = data.indexOf(config.unreleased) + config.unreleased.length;
+                const bufferedText = Buffer.from(`${config.changelogVersion}${data.substring(position)}`);
+                const file = fs.openSync(config.changelogPath, 'r+');
+                fs.writeSync(file, bufferedText, 0, bufferedText.length, position, err => {
+                    if (err) throw `Error writing file: ${err}`;
+                    fs.close(file);
+                });
+            }
+        }
+
         var promise = config.dryRun ? Q() : Q(config.versionProvider.writeVersion(config.newVersion));
-        return promise.then(function(result){
-            if (!config.quiet) console.log('Version bumped to ' + config.newVersion.bold.green);
+        return promise.then(result => {
+            if (!config.quiet) console.log(`Version bumped to ${config.newVersion.bold.green}`);
             return result;
         });
     },
-    add: function (config) {
-        return steps.run('git add ' + config.versionProvider.filePath,
-            'File ' + config.versionProvider.filePath + ' added', config.dryRun, config.quiet);
-    },
     commit: function (config) {
-        return steps.run('git commit ' + config.versionProvider.filePath + ' -m "' + config.commitMessage + '"',
-            'File ' + config.versionProvider.filePath + ' committed', config.dryRun, config.quiet);
+        return steps.run(`git commit -am "${config.commitMessage}"`, 'Files committed',
+            config.dryRun, config.quiet);
     },
     tag: function (config) {
-        return steps.run('git tag ' + config.tagName + ' -m "' + config.tagMessage + '"',
-            'Tag created: ' + config.tagName, config.dryRun, config.quiet);
+        return steps.run(`git tag ${config.tagName} -m "${config.tagMessage}"`,
+            `Tag created: ${config.tagName}`, config.dryRun, config.quiet);
     },
     push: function (config) {
-        var promise = steps.run('git version', '', config.dryRun, config.quiet).then(function(stdout){
-            var gitPushCommand = 'git push && git push --tags';
-            if (/(git version 1\.8\.3)|(git version 1\.8\.4)/.test(stdout)){
-              gitPushCommand = 'git push --follow-tags';
+        let promise = steps.run('git version', '', config.dryRun, config.quiet).then(stdout => {
+            let gitPushCommand = 'git push && git push --tags';
+            if (/(git version 1\.8\.3)|(git version 1\.8\.4)/.test(stdout)) {
+                gitPushCommand = 'git push --follow-tags';
+            }
+            // Post Release Notes at the github
+            if (fs.existsSync(config.changelogPath) && config.githubAuth) {
+                const releaseNotes = "curl -H " + config.githubAuth + " -X POST --data '"
+                    + JSON.stringify(config.release) + "' " + config.githubUrl
+                steps.run(releaseNotes, 'Post Release Notes', config.dryRun, config.quiet).then(err => {
+                    if (err) throw `Error on request ${err}`
+                })
+                // Tag already exists in the remote
+                gitPushCommand = 'git push';
             }
             return gitPushCommand;
         });
-        promise = promise.then(function(gitPushCommand){
+        promise = promise.then(gitPushCommand => {
             return steps.run(gitPushCommand, 'Pushed commit and tags', config.dryRun, config.quiet)
         });
         return promise;
     },
-    postReleasy: function(config) {
+    postReleasy: function (config) {
         var msg = 'Post releasy';
         return steps.scripts(msg, config, 'postreleasy');
     },
@@ -198,45 +221,42 @@ var steps = {
         return steps.run(cmd, msg, config.dryRun, config.quiet);
     },
     release: function (config, options) {
-      if (!config.quiet) console.log("Starting release...");
-      var promise = steps.preReleasy(config);
-      promise.then(function() {
-          return steps.bump(config)
-      });
-      if (options.commit) {
-        promise = promise.then(function () {
-          return steps.add(config)
+        if (!config.quiet) console.log("Starting release...");
+        var promise = steps.preReleasy(config);
+        promise.then(function () {
+            return steps.bump(config)
         });
-        promise = promise.then(function () {
-          return steps.commit(config)
+        if (options.commit) {
+            promise = promise.then(function () {
+                return steps.commit(config)
+            });
+        }
+        if (options.tag) {
+            promise = promise.then(function () {
+                return steps.tag(config)
+            });
+        }
+        if (options.push) {
+            promise = promise.then(function () {
+                return steps.push(config)
+            });
+        }
+        if (options.npm) {
+            promise = promise.then(function () {
+                return steps.publish(config)
+            });
+        }
+        promise = promise
+            .then(function () {
+                return steps.postReleasy(config)
+            })
+            .then(function () {
+                if (!config.quiet) console.log("All steps finished successfully.");
+            });
+        promise.fail(function (reason) {
+            if (!config.quiet) console.log("Failed to release.", reason);
         });
-      }
-      if (options.tag) {
-        promise = promise.then(function () {
-          return steps.tag(config)
-        });
-      }
-      if (options.push) {
-        promise = promise.then(function () {
-          return steps.push(config)
-        });
-      }
-      if (options.npm) {
-        promise = promise.then(function () {
-          return steps.publish(config)
-        });
-      }
-      promise = promise
-          .then(function() {
-              return steps.postReleasy(config)
-          })
-          .then(function() {
-              if (!config.quiet) console.log("All steps finished successfully.");
-          });
-      promise.fail(function(reason){
-        if (!config.quiet) console.log("Failed to release.", reason);
-      });
-      return promise;
+        return promise;
     }
 };
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -8,6 +8,7 @@ var path = require('path');
 var semver = require('semver');
 var yaml = require('js-yaml');
 var providers = require('./providers.js');
+var Github = require('github-api');
 
 var steps = {
     getOptionsFile: function () {
@@ -189,11 +190,12 @@ var steps = {
             }
             // Post Release Notes at the github
             if (fs.existsSync(config.changelogPath) && config.githubAuth) {
-                const releaseNotes = "curl -H " + config.githubAuth + " -X POST --data '"
-                    + JSON.stringify(config.release) + "' " + config.githubUrl
-                steps.run(releaseNotes, 'Post Release Notes', config.dryRun, config.quiet).then(err => {
-                    if (err) throw `Error on request ${err}`
-                })
+                const client = new Github({ token: config.githubAuth });
+                client.getRepo(config.githubInfo[0], config.githubInfo[1])
+                    .createRelease(config.release)
+                    .then((cb, err) => {
+                        if (err) throw `Error on request ${err}`
+                    })
                 // Tag already exists in the remote
                 gitPushCommand = 'git push';
             }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -11,33 +11,32 @@ var providers = require('./providers.js');
 var Github = require('github-api');
 
 var steps = {
-    getOptionsFile: function () {
-        var possibleFiles = ['_releasy.yaml', '_releasy.yml', '_releasy.json'];
-        for (var i = 0; i < possibleFiles.length; i++) {
-            var name = possibleFiles[i];
+    getOptionsFile: () => {
+        let possibleFiles = ['_releasy.yaml', '_releasy.yml', '_releasy.json'];
+        for (let i = 0; i < possibleFiles.length; i++) {
+            const name = possibleFiles[i];
             if (test('-e', name))
                 return yaml.safeLoad(cat(name));
         }
         return {};
     },
-    pickVersionProvider: function (fileName, overrideProviders) {
-        var currentProviders = overrideProviders || providers;
-        for (var i in currentProviders) {
-            var provider = currentProviders[i];
+    pickVersionProvider: (fileName, overrideProviders) => {
+        const currentProviders = overrideProviders || providers;
+        for (let i in currentProviders) {
+            const provider = currentProviders[i];
             if (provider.supports(fileName)) {
                 return new provider(fileName);
             }
         }
-
         throw new Error(util.format("Unable to find a provider that supports '%s' as a version file", fileName));
     },
-    setup: function (versionProvider, type, prerelease) {
-        var version = versionProvider.readVersion();
+    setup: (versionProvider, type, prerelease) => {
+        let version = versionProvider.readVersion();
         // Support for "promote" predicate, which bumps prerelease to stable, without changing version number.
         if (type === 'promote') {
             // Promote only makes sense when there is a prerelease
             if (version.prerelease.length === 0) {
-                throw new Error("The version you are trying to promote to stable (" + version.format() + ") is already stable.\n")
+                throw new Error(`The version you are trying to promote to stable (${version.format()}) is already stable.\n`)
             }
             else {
                 version.prerelease = [];
@@ -46,7 +45,7 @@ var steps = {
         }
         // For other types, simply increment
         else {
-            var incrementType = type === 'prerelease'
+            let incrementType = type === 'prerelease'
                 || prerelease === 'stable'
                 || version.prerelease.length === 0
                 ? type || 'patch'
@@ -62,10 +61,9 @@ var steps = {
             oldVersion: versionProvider.readVersion().format()
         };
     },
-    scripts: function (msg, config, key) {
-        var pkg = /package\.json$/.test(config.versionProvider.filePath);
-        var manifest = /manifest\.json$/.test(config.versionProvider.filePath);
-
+    scripts: (msg, config, key) => {
+        const pkg = /package\.json$/.test(config.versionProvider.filePath);
+        const manifest = /manifest\.json$/.test(config.versionProvider.filePath);
         if (!(pkg || manifest)) return Q();
         try {
             var cmd = config.versionProvider.getScript(key);
@@ -77,23 +75,23 @@ var steps = {
             steps.spawn(cmd, msg, config.dryRun, config.quiet)
             : Q();
     },
-    preReleasy: function (config) {
-        var msg = 'Pre releasy';
+    preReleasy: config => {
+        let msg = 'Pre releasy';
         return steps.status(config)
-            .then(function (stdout) {
+            .then(stdout => {
                 if (!config.dryRun && stdout[0].indexOf('nothing to commit') === -1) {
                     throw '\nPlease commit your changes before proceeding.';
                 } else {
                     return Q();
                 }
             })
-            .then(function () { return steps.scripts(msg, config, 'prereleasy'); })
-            .then(function () { return steps.status(config); })
-            .then(function (stdout) {
+            .then(() => { return steps.scripts(msg, config, 'prereleasy'); })
+            .then(() => { return steps.status(config); })
+            .then(stdout => {
                 if (stdout[0].indexOf('nothing to commit') > -1) return Q();
-                var cmd = config.versionProvider.getScript('prereleasy');
-                var preCfg = {
-                    commitMessage: 'Pre releasy commit\n\n' + cmd,
+                let cmd = config.versionProvider.getScript('prereleasy');
+                let preCfg = {
+                    commitMessage: `Pre releasy commit\n\n ${cmd}`,
                     dryRun: config.dryRun,
                     versionProvider: {
                         filePath: '.'
@@ -103,32 +101,32 @@ var steps = {
                 return steps.commit(preCfg);
             });
     },
-    run: function (cmd, successMessage, dryRun, quiet) {
-        var promise = dryRun ? Q() : Q.nfcall(exec, cmd);
-        if (successMessage) promise.then(function (stdout) {
+    run: (cmd, successMessage, dryRun, quiet) => {
+        let promise = dryRun ? Q() : Q.nfcall(exec, cmd);
+        if (successMessage) promise.then(stdout => {
             if (!quiet) console.log(successMessage + " > ".blue + cmd.blue);
             return stdout;
         });
         return promise;
     },
-    spawn: function (cmd, successMessage, dryRun, quiet) {
-        var deferred = Q.defer();
-        deferred.promise.then(function () {
+    spawn: (cmd, successMessage, dryRun, quiet) => {
+        let deferred = Q.defer();
+        deferred.promise.then(() => {
             if (!quiet) console.log(successMessage + " > ".blue + cmd.blue);
         });
         if (dryRun) {
             deferred.resolve();
             return deferred.promise;
         }
-        var childEnv = Object.create(process.env);
-        var childIO = quiet ? null : 'inherit';
-        var argsW32 = false;
+        let childEnv = Object.create(process.env);
+        let childIO = quiet ? null : 'inherit';
+        let argsW32 = false;
         if (/^(?:[A-Z]*_*)*[A-Z]*=/.test(cmd) && !dryRun) {
             var env = cmd.split('=');
             childEnv[env[0]] = env[1].split(' ')[0];
         }
         if (process.platform === 'win32') {
-            var argsCmd = env ? env[1].substr(env[1].indexOf(' ') + 1) : cmd;
+            let argsCmd = env ? env[1].substr(env[1].indexOf(' ') + 1) : cmd;
             var args = ['/s', '/c', argsCmd]
             var command = 'cmd.exe';
             argsW32 = true;
@@ -136,25 +134,25 @@ var steps = {
             var args = env ? env[1].split(' ').slice(1) : cmd.split(' ');
             var command = args.shift();
         }
-        var childProcess = spawn(command, args, { env: childEnv, stdio: childIO, windowsVerbatimArguments: argsW32 });
-        childProcess.on('close', function (code) {
+        let childProcess = spawn(command, args, { env: childEnv, stdio: childIO, windowsVerbatimArguments: argsW32 });
+        childProcess.on('close', code => {
             if (code === 0) deferred.resolve();
-            else deferred.reject('\nCommand exited with error code: ' + code);
+            else deferred.reject(`\nCommand exited with error code: ${code}`);
         });
         return deferred.promise;
     },
-    status: function (config) {
-        return steps.run('git status', '', false, config.quiet).then(function (stdout) {
+    status: config => {
+        return steps.run('git status', '', false, config.quiet).then(stdout => {
             return stdout;
         });
     },
-    bump: function (config) {
+    bump: config => {
         // Update version on CHANGELOG.md 
         if (fs.existsSync(config.changelogPath)) {
             const data = fs.readFileSync(config.changelogPath, err => {
                 if (err) throw `Error reading file: ${err}`;
             }).toString()
-            if (data.indexOf(config.unreleased) < 0) {
+            if (data.indexOf(config.unreleased) < 0 && !config.quiet) {
                 console.log("I can't update your CHANGELOG. :( \
                   \nMake your CHANGELOG great again and follow the CHANGELOG format http://keepachangelog.com/en/1.0.0/".red.bold)
             } else {
@@ -168,36 +166,37 @@ var steps = {
             }
         }
 
-        var promise = config.dryRun ? Q() : Q(config.versionProvider.writeVersion(config.newVersion));
+        let promise = config.dryRun ? Q() : Q(config.versionProvider.writeVersion(config.newVersion));
         return promise.then(result => {
             if (!config.quiet) console.log(`Version bumped to ${config.newVersion.bold.green}`);
             return result;
         });
     },
-    commit: function (config) {
-        return steps.run(`git commit -am "${config.commitMessage}"`, 'Files committed',
+    add: config => {
+        let gitAddCommand = `git add ${config.versionProvider.filePath}`
+        let successMessage = `File ${config.versionProvider.filePath} added`
+        if (fs.existsSync(config.changelogPath)) {
+            gitAddCommand = `git add ${config.versionProvider.filePath} ${config.changelogPath}`
+            successMessage = `Files ${config.versionProvider.filePath} ${config.changelogPath} added`
+        }
+        return steps.run(gitAddCommand, successMessage, config.dryRun, config.quiet);
+    },
+    commit: config => {
+        let successMessage = `File ${config.versionProvider.filePath} commited`
+        if (fs.existsSync(config.changelogPath)) successMessage =
+            `Files ${config.versionProvider.filePath} ${config.changelogPath} commited`
+        return steps.run(`git commit -m "${config.commitMessage}"`, successMessage,
             config.dryRun, config.quiet);
     },
-    tag: function (config) {
+    tag: config => {
         return steps.run(`git tag ${config.tagName} -m "${config.tagMessage}"`,
             `Tag created: ${config.tagName}`, config.dryRun, config.quiet);
     },
-    push: function (config) {
+    push: config => {
         let promise = steps.run('git version', '', config.dryRun, config.quiet).then(stdout => {
             let gitPushCommand = 'git push && git push --tags';
             if (/(git version 1\.8\.3)|(git version 1\.8\.4)/.test(stdout)) {
                 gitPushCommand = 'git push --follow-tags';
-            }
-            // Post Release Notes at the github
-            if (fs.existsSync(config.changelogPath) && config.githubAuth) {
-                const client = new Github({ token: config.githubAuth });
-                client.getRepo(config.githubInfo[0], config.githubInfo[1])
-                    .createRelease(config.release)
-                    .then((cb, err) => {
-                        if (err) throw `Error on request ${err}`
-                    })
-                // Tag already exists in the remote
-                gitPushCommand = 'git push';
             }
             return gitPushCommand;
         });
@@ -206,57 +205,78 @@ var steps = {
         });
         return promise;
     },
-    postReleasy: function (config) {
-        var msg = 'Post releasy';
+    releaseNotes: config => {
+        // Post Release Notes at the Github
+        const { changelogPath, githubAuth, githubInfo, release } = config
+        if (fs.existsSync(changelogPath) && githubAuth) {
+            const client = new Github({ token: githubAuth });
+            client.getRepo(githubInfo[0], githubInfo[1])
+                .createRelease(release)
+                .then(() => {
+                    if (!config.quiet) console.log("Release Notes submitted".green)
+                })
+                .catch(err => {
+                    throw `Error on request ${err}`
+                })
+        }
+    },
+    postReleasy: config => {
+        const msg = 'Post releasy';
         return steps.scripts(msg, config, 'postreleasy');
     },
-    publish: function (config) {
-        var cmd = 'npm publish';
-        var msg = 'Published ' + config.newVersion + ' to npm';
+    publish: config => {
+        let cmd = 'npm publish';
+        let msg = `Published ${config.newVersion} to npm`;
         if (config.npmTag) {
-            cmd += ' --tag ' + config.npmTag;
-            msg += ' with a tag of "' + config.npmTag + '"';
+            cmd += ` --tag ${config.npmTag}`;
+            msg += `with a tag of "${config.npmTag}"`;
         }
         if (config.npmFolder) {
-            cmd += ' ' + config.npmFolder
+            cmd += ` ${config.npmFolder}`
         }
         return steps.run(cmd, msg, config.dryRun, config.quiet);
     },
-    release: function (config, options) {
+    release: (config, options) => {
         if (!config.quiet) console.log("Starting release...");
-        var promise = steps.preReleasy(config);
-        promise.then(function () {
+        let promise = steps.preReleasy(config);
+        promise.then(() => {
             return steps.bump(config)
         });
         if (options.commit) {
-            promise = promise.then(function () {
+            promise = promise.then(() => {
+                return steps.add(config)
+            });
+            promise = promise.then(() => {
                 return steps.commit(config)
             });
         }
         if (options.tag) {
-            promise = promise.then(function () {
+            promise = promise.then(() => {
                 return steps.tag(config)
             });
         }
         if (options.push) {
-            promise = promise.then(function () {
+            promise = promise.then(() => {
                 return steps.push(config)
+            });
+            promise = promise.then(() => {
+                return steps.releaseNotes(config)
             });
         }
         if (options.npm) {
-            promise = promise.then(function () {
+            promise = promise.then(() => {
                 return steps.publish(config)
             });
         }
         promise = promise
-            .then(function () {
+            .then(() => {
                 return steps.postReleasy(config)
             })
-            .then(function () {
-                if (!config.quiet) console.log("All steps finished successfully.");
+            .then(() => {
+                if (!config.quiet) console.log("All steps finished successfully.".green);
             });
-        promise.fail(function (reason) {
-            if (!config.quiet) console.log("Failed to release.", reason);
+        promise.fail(reason => {
+            if (!config.quiet) console.error("[ERROR] Failed to release.\n".red.bold, reason);
         });
         return promise;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,429 @@
+{
+  "name": "releasy",
+  "version": "1.7.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
+    "coffee-script": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
+      "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+    },
+    "prompt": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.3.0.tgz",
+      "integrity": "sha1-k6S9RTsu5TF7PCu2ZrIMHOtFQTg=",
+      "requires": {
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.2.x",
+        "winston": "0.8.x"
+      }
+    },
+    "q": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
+    },
+    "should": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/should/-/should-3.3.2.tgz",
+      "integrity": "sha1-yIPdQJtTu98bVewNj8OGXysofmQ=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "utile": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+      "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
+      "requires": {
+        "async": "~0.2.9",
+        "deep-equal": "*",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "0.4.x",
+        "rimraf": "2.x.x"
+      }
+    },
+    "winston": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+      "requires": {
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
+      },
+      "dependencies": {
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,15 @@
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
+    "axios": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.15.3.tgz",
+      "integrity": "sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -107,6 +116,26 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
+    "follow-redirects": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
+      "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "formatio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
@@ -120,6 +149,29 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "github-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/github-api/-/github-api-3.0.0.tgz",
+      "integrity": "sha1-KDL5jQ06g/FIXi2zLJJZ5LnECnU=",
+      "dev": true,
+      "requires": {
+        "axios": "^0.15.2",
+        "debug": "^2.2.0",
+        "js-base64": "^2.1.9",
+        "utf8": "^2.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -180,6 +232,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js-base64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.11.0",
@@ -368,6 +426,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+      "dev": true
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releasy",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "CLI tool to release node applications with tag and auto semver bump",
   "main": "lib/releasy.js",
   "bin": "bin/releasy.js",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "preferGlobal": true,
   "devDependencies": {
     "coffee-script": "~1.10.0",
+    "github-api": "^3.0.0",
     "mocha": "^5.2.0",
     "should": "~3.3.1",
     "sinon": "~1.17.3"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "preferGlobal": true,
   "devDependencies": {
     "coffee-script": "~1.10.0",
-    "mocha": "^2.5.3",
+    "mocha": "^5.2.0",
     "should": "~3.3.1",
     "sinon": "~1.17.3"
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
The changelog is automatically updated such as the manifest and if the user sets the env `GITHUB_API_TOKEN` we post the changes on GitHub release notes. 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Now, `releasy` can automatically update projects that have a `CHANGELOG.md` and create release notes at GitHub repository. 
 
#### How should this be manually tested?
- Clone this branch
- Enter into a project which a `CHANGELOG.md`. 
- Execute `node ../releasy/bin/releasy.js`

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.