### PR TITLE
Fix parse to get repo info when clone is via SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Better explanation for the `CHANGELOG` workflow
+
+### Fixed
+- Fix parse to get repo info when clone is via SSH. 
 
 ## [1.8.1] - 2018-6-4
 

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -78,18 +78,16 @@ module.exports = function (opts) {
 
   /**
    * Get information about org and repo name
-   * @return git organization and repo names
+   * @return array with git organization and repo
   */
   function getGithubRepo() {
-    gitUrlCommand = 'git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3'
-    const url = execSync(gitUrlCommand).toString().replace(".git", "").trim()
-    if (url.includes('git@git')) {
-      [aux] = url.split(":").slice(-1)
-      const repo = aux.split("/")
-      return repo
-    }
-    const repo = url.split("/").slice(-2)
-    return repo
+    return execSync('git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3')
+      .toString()
+      .replace(".git", "")
+      .trim()
+      .split(":")[1]
+      .split("/")
+      .slice(-2)
   }
 
   // No prompt necessary, release and finish.

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -82,13 +82,13 @@ module.exports = function (opts) {
   */
   function getGithubRepo() {
     gitUrlCommand = 'git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3'
-    const url = execSync(gitUrlCommand).toString().trim();
+    const url = execSync(gitUrlCommand).toString().replace(".git", "").trim();
     if (url.includes('git@git')) {
       [aux] = url.split(":").slice(1)
       const repo = aux.split("/")
       return repo
     }
-    const repo = url.replace(".git", "").split("/").slice(3)
+    const repo = url.split("/").slice(3)
     return repo
   }
 

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -82,7 +82,7 @@ module.exports = function (opts) {
   */
   function getGithubRepo() {
     gitUrlCommand = 'git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3'
-    const url = execSync(gitUrlCommand).toString().replace(".git", "").trim();
+    const url = execSync(gitUrlCommand).toString().replace(".git", "").trim()
     if (url.includes('git@git')) {
       [aux] = url.split(":").slice(1)
       const repo = aux.split("/")

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -82,14 +82,12 @@ module.exports = function (opts) {
   */
   function getGithubRepo() {
     return execSync('git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3')
-      .toString()
+      .toString().trim()
       .replace(".git", "")
-      .trim()
       .split(":")[1]
       .split("/")
       .slice(-2)
   }
-
   // No prompt necessary, release and finish.
   if (!opts.cli || opts.silent) {
     this.promise = this.steps.release(config, opts);

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -84,11 +84,11 @@ module.exports = function (opts) {
     gitUrlCommand = 'git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3'
     const url = execSync(gitUrlCommand).toString().replace(".git", "").trim()
     if (url.includes('git@git')) {
-      [aux] = url.split(":").slice(1)
+      [aux] = url.split(":").slice(-1)
       const repo = aux.split("/")
       return repo
     }
-    const repo = url.split("/").slice(3)
+    const repo = url.split("/").slice(-2)
     return repo
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix parse to get repo info when clone is via SSH

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Fix ssh clone scenario that cause this error: 
```
(node:50488) UnhandledPromiseRejectionWarning: Error on request Error: 404 error making request POST https://api.github.com/repos/vtex/checkout-instore.git/releases: "Not Found"
(node:50488) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:50488) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
