### PR TITLE
Change method to avoid the usage of grep and cut commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed 
+- Change `getGitHubRepo` to avoid the usage of `grep` and `cut` commands. 
 
 ## [1.9.0] - 2018-6-18
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.9.1] - 2018-6-19
 ### Changed 
 - Change `getGitHubRepo` to avoid the usage of `grep` and `cut` commands. 
 

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -86,7 +86,7 @@ module.exports = function (opts) {
    * @return array with git organization and repo
   */
   function getGithubRepo() {
-    return execSync('git remote show origin -n | grep "Fetch URL:" | cut -d ":" -f2 -f3')
+    return execSync('git remote get-url origin')
       .toString().trim()
       .replace('.git', '')
       .split(':')[1]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releasy",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "CLI tool to release node applications with tag and auto semver bump",
   "main": "lib/releasy.js",
   "bin": "bin/releasy.js",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the way to get organization and repo names. This approach is to prevent any OS compatibility problem. 

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
