### PR TITLE
Fix colored messages logged as undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.10.4] - 2020-08-10
 ### Fixed
 - Colored messages printed as `undefined`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Colored messages printed as `undefined`.
 
 ## [1.10.3] - 2020-08-10
 

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -138,7 +138,7 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
   const property = {
     name: 'confirm',
     type: 'string',
-    description: 'Are you sure?'.green,
+    description: chalk.green('Are you sure?'),
     default: 'yes',
     required: true,
     before: (value) => {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -132,7 +132,9 @@ const steps = {
 
     if (successMessage) {
       promise.then((stdout) => {
-        if (!quiet) console.log(successMessage + ' > '.blue + cmd.blue)
+        if (!quiet) {
+          console.log(chalk`${successMessage} {blue > ${cmd}}`)
+        }
 
         return stdout
       })
@@ -144,7 +146,9 @@ const steps = {
     const deferred = Q.defer()
 
     deferred.promise.then(() => {
-      if (!quiet) console.log(successMessage + ' > '.blue + cmd.blue)
+      if (!quiet) {
+        console.log(chalk`${successMessage} {blue > ${cmd}}`)
+      }
     })
 
     if (dryRun) {
@@ -298,13 +302,15 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
         .getRepo(githubInfo[0], githubInfo[1])
         .createRelease(release)
         .then(() => {
-          if (!config.quiet) console.log('Release Notes submitted'.green)
+          if (!config.quiet) console.log(chalk.green('Release Notes submitted'))
         })
         .catch((err) => {
           throw new Error(`Error on request ${err}`)
         })
     } else {
-      console.log("You don't have a CHANGELOG to post Release Notes".yellow)
+      console.log(
+        chalk.yellow("You don't have a CHANGELOG to post Release Notes")
+      )
     }
   },
   postReleasy: (config) => {
@@ -372,7 +378,9 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
         return steps.postReleasy(config)
       })
       .then(() => {
-        if (!config.quiet) console.log('All steps finished successfully.'.green)
+        if (!config.quiet) {
+          console.log(chalk.green('All steps finished successfully.'))
+        }
       })
     promise.fail((reason) => {
       if (!config.quiet)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releasy",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "CLI tool to release node applications with tag and auto semver bump",
   "main": "lib/releasy.js",
   "bin": "bin/releasy.js",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates remaining strings to use `chalk` instead of the previous prototype-based for message coloring.

#### What problem is this solving?

Fix colored messages being logged as `undefined`.

![image](https://user-images.githubusercontent.com/10223856/89792426-ea8cda00-dafa-11ea-8b75-460d29aacd06.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.