### PR TITLE
Add support for NPM two-factor authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.11.0] - 2020-08-12
 ### Added
 - Flag `--otp` to handle NPM two-factor authentication.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Flag `--otp` to handle NPM two-factor authentication.
 
 ## [1.10.5] - 2020-08-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Flag `--otp` to handle NPM two-factor authentication.
 
+### Fixed
+- Error when trying to push an inexistent tag (with `releasy --no-tag`).
+
 ## [1.10.5] - 2020-08-10
 ### Changed
 - Remove `q` promise library in favor of native `Promise` object.

--- a/bin/releasy.js
+++ b/bin/releasy.js
@@ -30,6 +30,7 @@ program
   .option('-t, --tag-name [tag]', 'The prerelease tag in your version', 'beta')
   .option('--npm-tag [tag]', 'Tag option for npm publish', '')
   .option('-f, --folder [folder]', 'Folder option for npm publish', '')
+  .option('--otp [code]', 'One-time password code for npm publish')
   .option('--stable', 'Mark this as a relese stable (no prerelease tag)', false)
   .option('--no-commit', 'Do not commit the version change', false)
   .option('--no-tag', 'Do not tag the version change', false)

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -18,7 +18,9 @@ module.exports = function (opts) {
     opts.stable ? 'stable' : opts.tagName
   )
 
-  if (!opts.quiet) {
+  const quiet = opts.quiet || process.env.NODE_ENV === 'test'
+
+  if (!quiet) {
     console.log(`Old version: ${chalk.bold(config.oldVersion)}`)
     console.log(`New version: ${chalk.yellow.bold(config.newVersion)}`)
   }
@@ -36,7 +38,7 @@ module.exports = function (opts) {
   config.npmTag = opts.npmTag
   config.npmFolder = opts.npmFolder
   config.dryRun = opts.dryRun
-  config.quiet = opts.quiet
+  config.quiet = quiet
   config.unreleased = '## [Unreleased]'
   config.changelogPath = 'CHANGELOG.md'
   config.githubAuth = getGithubToken()
@@ -146,13 +148,15 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
     },
   }
 
-  prompt.get(property, (err, result) => {
-    if (err || !result.confirm) {
-      return console.log('\nCancelled by user')
-    }
+  return new Promise((resolve, reject) => {
+    prompt.get(property, (err, result) => {
+      if (err || !result.confirm) {
+        console.log('\nCancelled by user')
 
-    steps.release(config, opts)
+        return
+      }
+
+      steps.release(config, opts).then(resolve, reject)
+    })
   })
-
-  return Promise.resolve()
 }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -128,11 +128,9 @@ const steps = {
     await steps.commit(preCfg)
   },
   run: async (cmd, successMessage, dryRun, quiet) => {
-    const promise = dryRun
+    const stdout = await (dryRun
       ? Promise.resolve('')
-      : execAsync(cmd).then(({ stdout }) => stdout)
-
-    const stdout = await promise
+      : execAsync(cmd).then((result) => result.stdout))
 
     if (successMessage && !quiet) {
       console.log(chalk`${successMessage} {blue > ${cmd}}`)

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -365,8 +365,7 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
                   otpMessage: 'Incorrect or expired OTP',
                   otpRetries: otpRetries - 1,
                 })
-                .then(resolve)
-                .catch(reject)
+                .then(resolve, reject)
             }
           )
         })

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -6,6 +6,7 @@ const chalk = require('chalk')
 const { cat, test } = require('shelljs')
 const Github = require('github-api')
 const yaml = require('js-yaml')
+const prompt = require('prompt')
 
 const providers = require('./providers.js')
 
@@ -126,22 +127,18 @@ const steps = {
 
     await steps.commit(preCfg)
   },
-  run: (cmd, successMessage, dryRun, quiet) => {
+  run: async (cmd, successMessage, dryRun, quiet) => {
     const promise = dryRun
       ? Promise.resolve('')
       : execAsync(cmd).then(({ stdout }) => stdout)
 
-    if (successMessage) {
-      promise.then((stdout) => {
-        if (!quiet) {
-          console.log(chalk`${successMessage} {blue > ${cmd}}`)
-        }
+    const stdout = await promise
 
-        return stdout
-      })
+    if (successMessage && !quiet) {
+      console.log(chalk`${successMessage} {blue > ${cmd}}`)
     }
 
-    return promise
+    return stdout
   },
   spawn: (cmd, successMessage, dryRun, quiet) => {
     return new Promise((resolve, reject) => {
@@ -316,7 +313,7 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
 
     return steps.scripts(msg, config, 'postreleasy')
   },
-  publish: (config) => {
+  publish: async (config, { otp = '', otpMessage = '' }) => {
     let cmd = 'npm publish'
     let msg = `Published ${config.newVersion} to npm`
 
@@ -325,19 +322,61 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
       msg += `with a tag of "${config.npmTag}"`
     }
 
+    if (otp) {
+      cmd += ` --otp ${otp}`
+    }
+
     if (config.npmFolder) {
       cmd += ` ${config.npmFolder}`
     }
 
-    return steps.run(cmd, msg, config.dryRun, config.quiet)
+    try {
+      return await steps.run(cmd, msg, config.dryRun, config.quiet)
+    } catch (error) {
+      if (error.message.includes('code EOTP')) {
+        if (otpMessage) {
+          console.log(otpMessage)
+        }
+
+        return new Promise((resolve, reject) => {
+          // User has enabled two-factor authentication to
+          // publish NPM packages, so prompt user for it and retry publishing
+          prompt.start()
+          prompt.get(
+            {
+              name: 'opt',
+              type: 'string',
+              description: 'npm one-time password',
+              default: '',
+              required: true,
+            },
+            (err, result) => {
+              if (err || !result.opt) {
+                throw new Error('Cancelled by user')
+              }
+
+              steps
+                .publish(config, {
+                  otp: result.otp,
+                  otpMessage: 'Incorrect or expired OTP',
+                })
+                .then(resolve)
+                .catch(reject)
+            }
+          )
+        })
+      }
+
+      throw error
+    }
   },
   release: async (config, options) => {
     try {
       if (!config.quiet) console.log('Starting release...')
 
       await steps.preReleasy(config)
-
       await steps.bump(config)
+
       if (options.commit) {
         await steps.add(config)
         await steps.commit(config)
@@ -356,10 +395,11 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
       }
 
       if (options.npm) {
-        await steps.publish(config)
+        await steps.publish(config, { otp: options.otp })
       }
 
       await steps.postReleasy(config)
+
       if (!config.quiet) {
         console.log(chalk.green('All steps finished successfully.'))
       }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -278,7 +278,7 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
   },
   push: (config) => {
     return steps.run(
-      `git push && git push origin ${config.tagName}`,
+      `git push --follow-tags`,
       'Pushed commit and tags',
       config.dryRun,
       config.quiet

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -313,7 +313,7 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
 
     return steps.scripts(msg, config, 'postreleasy')
   },
-  publish: async (config, { otp = '', otpMessage = '' }) => {
+  publish: async (config, { otp = '', otpMessage = '', otpRetries = 0 }) => {
     let cmd = 'npm publish'
     let msg = `Published ${config.newVersion} to npm`
 
@@ -333,7 +333,9 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
     try {
       return await steps.run(cmd, msg, config.dryRun, config.quiet)
     } catch (error) {
-      if (error.message.includes('code EOTP')) {
+      const isOTPError = error.message.includes('code EOTP')
+
+      if (isOTPError && otpRetries > 0) {
         if (otpMessage) {
           console.log(otpMessage)
         }
@@ -344,27 +346,36 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
           prompt.start()
           prompt.get(
             {
-              name: 'opt',
+              name: 'otp',
               type: 'string',
               description: 'npm one-time password',
               default: '',
               required: true,
             },
             (err, result) => {
-              if (err || !result.opt) {
-                throw new Error('Cancelled by user')
+              if (err || !result.otp) {
+                reject('Cancelled by user')
+
+                return
               }
 
               steps
                 .publish(config, {
                   otp: result.otp,
                   otpMessage: 'Incorrect or expired OTP',
+                  otpRetries: otpRetries - 1,
                 })
                 .then(resolve)
                 .catch(reject)
             }
           )
         })
+      }
+
+      if (isOTPError) {
+        throw new Error(
+          'OTP code is incorrect or expired and you have runned out of attemps'
+        )
       }
 
       throw error
@@ -395,7 +406,13 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
       }
 
       if (options.npm) {
-        await steps.publish(config, { otp: options.otp })
+        await steps.publish(config, {
+          otp: options.otp,
+          // In case the otp code was passed via options, we won't
+          // retry as this is likely a script which won't know how
+          // to respond to our prompt in case the publish fails
+          otpRetries: options.otp ? 0 : 3,
+        })
       }
 
       await steps.postReleasy(config)
@@ -405,7 +422,10 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
       }
     } catch (reason) {
       if (!config.quiet) {
-        console.error(chalk.red.bold('[ERROR] Failed to release.\n'), reason)
+        console.error(
+          chalk.red.bold('[ERROR] Failed to release.\n'),
+          reason instanceof Error ? reason.message : reason
+        )
       }
     }
   },

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -276,7 +276,7 @@ Make your CHANGELOG great again and follow the CHANGELOG format http://keepachan
   },
   push: (config) => {
     return steps.run(
-      `git push --follow-tags`,
+      'git push --follow-tags',
       'Pushed commit and tags',
       config.dryRun,
       config.quiet

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-config-vtex": "^12.8.2",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
+    "mock-fs": "^4.12.0",
     "prettier": "^2.0.5",
     "typescript": "^3.9.7"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releasy",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "description": "CLI tool to release node applications with tag and auto semver bump",
   "main": "lib/releasy.js",
   "bin": "bin/releasy.js",

--- a/test/otp.test.js
+++ b/test/otp.test.js
@@ -1,0 +1,119 @@
+const prompt = require('prompt')
+const mockFs = require('mock-fs')
+
+const releasy = require('../lib/releasy')
+const steps = require('../lib/steps')
+
+describe('npm OTP', () => {
+  beforeEach(() => {
+    mockFs({
+      'package.json': JSON.stringify({
+        version: '0.0.0',
+      }),
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    mockFs.restore()
+  })
+
+  it('should ask for a otp if 2FA is enabled', async () => {
+    jest.spyOn(steps, 'status').mockReturnValue('nothing to commit')
+    jest.spyOn(prompt, 'get').mockImplementationOnce((schema, callback) => {
+      callback(null, { [schema.name]: '123456' })
+    })
+
+    const runSpy = jest.spyOn(steps, 'run').mockImplementation((cmd) => {
+      if (cmd === 'npm publish') {
+        // Pretend user has 2FA active
+        return Promise.reject(new Error('npm ERR! code EOTP'))
+      }
+
+      return 'ok'
+    })
+
+    await releasy({
+      filename: 'package.json',
+      type: 'minor',
+      npm: true,
+    })
+
+    expect(runSpy).toHaveBeenCalledTimes(2)
+    expect(runSpy).toHaveBeenLastCalledWith(
+      'npm publish --otp 123456',
+      expect.anything(),
+      undefined,
+      true
+    )
+    mockFs.restore()
+  })
+
+  it('should cancel publish if no otp is provided', async () => {
+    jest.spyOn(steps, 'status').mockReturnValue('nothing to commit')
+    jest.spyOn(prompt, 'get').mockImplementationOnce((schema, callback) => {
+      callback(null, { [schema.name]: '' })
+    })
+    const publishSpy = jest.spyOn(steps, 'publish')
+    const runSpy = jest.spyOn(steps, 'run').mockImplementation((cmd) => {
+      if (cmd === 'npm publish') {
+        // Pretend user has 2FA active
+        return Promise.reject(new Error('npm ERR! code EOTP'))
+      }
+
+      return 'ok'
+    })
+
+    await releasy({
+      filename: 'package.json',
+      type: 'minor',
+      npm: true,
+    })
+
+    expect(publishSpy).toHaveBeenCalledTimes(1)
+    await expect(publishSpy.mock.results[0].value).rejects.toBe(
+      'Cancelled by user'
+    )
+    expect(runSpy).toHaveBeenCalledTimes(1)
+    expect(runSpy).toHaveBeenLastCalledWith(
+      'npm publish',
+      expect.anything(),
+      undefined,
+      true
+    )
+    mockFs.restore()
+  })
+
+  it('should fail to publish if incorrect otp is passed via CLI options', async () => {
+    jest.spyOn(steps, 'status').mockReturnValue('nothing to commit')
+
+    const publishSpy = jest.spyOn(steps, 'publish')
+    const runSpy = jest.spyOn(steps, 'run').mockImplementation((cmd) => {
+      if (cmd === 'npm publish --otp 123456') {
+        return Promise.reject(new Error('npm ERR! code EOTP'))
+      }
+
+      return 'ok'
+    })
+
+    await releasy({
+      filename: 'package.json',
+      type: 'minor',
+      npm: true,
+      otp: '123456',
+    })
+
+    expect(publishSpy).toHaveReturnedTimes(1)
+    await expect(publishSpy.mock.results[0].value).rejects.toThrow(
+      'OTP code is incorrect or expired and you have runned out of attemps'
+    )
+    expect(runSpy).toHaveBeenCalledTimes(1)
+    expect(runSpy).toHaveBeenLastCalledWith(
+      'npm publish --otp 123456',
+      expect.anything(),
+      undefined,
+      true
+    )
+    mockFs.restore()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4700,6 +4700,11 @@ mkdirp@0.x.x, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mock-fs@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.12.0.tgz#a5d50b12d2d75e5bec9dac3b67ffe3c41d31ade4"
+  integrity sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds support for NPM 2FA using a one-time password code, which can now be passed with either the `--otp` flag or by typing it when prompted in the publish step.

#### What problem is this solving?

Resolves #41 

#### How should this be manually tested?

I added tests to cover this functionality, so you can just run `yarn test`.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
