### PR TITLE
Enabling no prefix tag

### DIFF
--- a/bin/releasy.js
+++ b/bin/releasy.js
@@ -53,6 +53,7 @@ program
   )
   .option('-s, --silent', 'Dont ask for confirmation', false)
   .option('-q, --quiet', "Don't write messages to console", false)
+  .option('--no-prefix', 'Ignore version prefix', false)
   .parse(args)
 
 for (let [key, value] of Object.entries(optionsFile)) {

--- a/lib/releasy.js
+++ b/lib/releasy.js
@@ -32,7 +32,15 @@ module.exports = function (opts) {
   const year = dateArray[2]
 
   // Pachamama v2 requires that version tags start with a 'v' character.
-  config.tagName = `v${config.newVersion}`
+
+  let prefix = 'v';
+  
+  if(!opts.prefix) {
+    prefix = '';
+  }
+  
+  config.tagName = `${prefix}${config.newVersion}`
+  
   if (opts.displayName) {
     // TODO: Validade with @reliability if the pachamama accepts this new tag structure.
     config.tagName = `${versionProvider.readName()}@${config.newVersion}`


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enable tag release with no prefix

#### What problem is this solving?
Using current releasy version we get urls with the prefix v, like this
https://io.vtex.com.br/i18n/v0.1.183/catalog/en-US.json
but we want them with no prefix, like this
https://io.vtex.com.br/i18n/0.1.184/catalog/en-US.json?

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
